### PR TITLE
fix custom configuration file path bug

### DIFF
--- a/cloudkitty/api/app.py
+++ b/cloudkitty/api/app.py
@@ -105,7 +105,7 @@ def load_app():
 
 
 def build_wsgi_app(argv=None):
-    service.prepare_service([])
+    service.prepare_service()
     return load_app()
 
 


### PR DESCRIPTION
The  parameter [] is not None, so when we specified a custom configuration file(such as '/my/etc/cloudkitty/cloudkitty.conf' not the default '/etc/cloudkitty/cloudkitty.conf'), it didn't work, the cloudkitty still load the default configuration file. We need to set the parameter to None.